### PR TITLE
Add GitHub actions for syntax checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard_bug.md
+++ b/.github/ISSUE_TEMPLATE/standard_bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Standard SMF Bug report
+
+---
+
+#### Description
+--Description Here--
+
+### Steps to reproduce
+1. 
+2. 
+
+### Environment (complete as necessary)
+- Version/Git revision:
+- Database Type:
+- Database Version:
+- PHP Version:
+
+
+### Additional information/references

--- a/.github/PULL_REQUEST_TEMPLATE/standard_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard_pr.md
@@ -1,0 +1,12 @@
+---
+name: Pull Request
+about: Standard SMF Pull Request
+
+---
+
+#### Description
+--PR Summary here--
+
+### Issues References (Fixes|Related|Closes)
+1. 
+2. 

--- a/.github/check-php-syntax.php
+++ b/.github/check-php-syntax.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2020 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 RC3
+ */
+
+// Stuff we will ignore.
+$ignoreFiles = array(
+);
+
+/* This is mostly meant for local usage.
+   To add additional PHP Binaries, create a check-php-syntax-binaries.txt
+   Add in this in each line the binary file, i.e: /usr/bin/php
+*/
+$addditionalPHPBinaries = array();
+if (file_exists(dirname(__FILE__) . '/check-php-syntax-binaries.txt'))
+	$addditionalPHPBinaries = file(dirname(__FILE__) . '/check-php-syntax-binaries.txt');
+
+$curDir = '.';
+if (isset($_SERVER['argv'], $_SERVER['argv'][1]))
+	$curDir = $_SERVER['argv'][1];
+
+$foundBad = false;
+foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($curDir, FilesystemIterator::UNIX_PATHS)) as $currentFile => $fileInfo)
+{
+	// Only check PHP
+	if ($fileInfo->getExtension() !== 'php')
+		continue;
+
+	foreach ($ignoreFiles as $if)
+		if (preg_match('~' . $if . '~i', $currentFile))
+			continue 2;
+
+	# Always check against the base.
+	$result = trim(shell_exec('php -l ' . $currentFile));
+
+	if (!preg_match('~No syntax errors detected in ' . $currentFile . '~', $result))
+	{
+		$foundBad = true;
+		fwrite(STDERR, 'PHP via $PATH: ' . $result . "\n");
+		continue;
+	}
+
+	// We have additional binaries we want to test against?
+	foreach ($addditionalPHPBinaries as $binary)
+	{
+		$binary = trim($binary);
+		$result = trim(shell_exec($binary . ' -l ' . $currentFile));
+
+		if (!preg_match('~No syntax errors detected in ' . $currentFile . '~', $result))
+		{
+			$foundBad = true;
+			fwrite(STDERR, 'PHP via ' . $binary . ': ' . $result . "\n");
+			continue 2;
+		}
+	}
+}
+
+if (!empty($foundBad))
+	exit(1);

--- a/.github/workflows/Syntax-Check.yml
+++ b/.github/workflows/Syntax-Check.yml
@@ -1,0 +1,22 @@
+name: PHP Syntax Check
+
+on: [push, pull_request]
+
+jobs:
+  syntax-checker:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+    name: PHP ${{ matrix.php }} Syntax Check
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: true
+      - name: Setup PHP
+        id: SetupPHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+      - run: php ./.github/check-php-syntax.php ./

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,17 @@
+ForumSessionProvider License
+============================
+Copyright (c) 2020, Simple Machines
+Copyright (c) 2019, SleePy
+Copyright (c) 2019, Vekseid
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ForumSsoProvider.php
+++ b/ForumSsoProvider.php
@@ -128,6 +128,10 @@ class ForumSsoProvider extends \MediaWiki\Session\ImmutableSessionProviderWithCo
 	{
 		global $wgForumSessionProviderInstance;
 
+		// Ensure its callable.
+		if (!is_callable($wgForumSessionProviderInstance, 'doRedirect'))
+			return;
+
 		// The case of some of these isn't always consistent with what shows up in the url.
 		$special_action = strtolower($special->getName());
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To use, the contents of the ForumSsoProvider directory need to be placed into ex
     wfLoadExtension('ForumSsoProvider');
 
 # Required LocalSettings
+All settings should be defined prior to calling `wfLoadExtension('ForumSsoProvider');` in your LocalSettings.php
 ### Path to Forum Software
 
     $wgSMFPath = '/path/to/smf/root/';
@@ -106,21 +107,8 @@ This bloats pretty quickly, so you'll want to comment it out after you have reso
 ----
 Getting New SMF Forks In
 ------------------------
-If you are familiar with how your fork's authentication works, feel free to submit a pull request. 
+If you are familiar with how your fork's authentication works, feel free to submit a pull request.
 
 Issues or changes
 ------------------------
 If an issue has occurred, please open a new issue.  If you have a change, please submit a pull request.
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fix bug where not setting up variables prior to calling the extension may result in an error.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>